### PR TITLE
Fixed bug when sending message after disconnected

### DIFF
--- a/index.js
+++ b/index.js
@@ -486,9 +486,8 @@ class SockhopClient extends EventEmitter{
 			if(callback) throw new Error("Unable to use remote callback - peer type must be Sockhop");
 		}	
 
-		if(this._socket.destroyed){
+		if(this._socket == null){
 
-			this._socket.emit("end");
 			return Promise.reject(new Error("Client unable to send() - socket has been destroyed"));
 		}
 

--- a/index.js
+++ b/index.js
@@ -486,7 +486,7 @@ class SockhopClient extends EventEmitter{
 			if(callback) throw new Error("Unable to use remote callback - peer type must be Sockhop");
 		}	
 
-		if(this._socket == null){
+		if((this._socket && this._socket.destroyed) || this._socket === null){
 
 			return Promise.reject(new Error("Client unable to send() - socket has been destroyed"));
 		}

--- a/test/client-server.js
+++ b/test/client-server.js
@@ -19,6 +19,11 @@ describe("Client-server", function(){
 			done();
 		});
 	});
+	it("client.connect returns if connected",function(done){
+
+			c.connect()
+			.then(()=>done());
+	});
 	it("client.connected transitions from true to false on disconnect",function(done){
 
 		assert.equal(c.connected,true);
@@ -29,7 +34,12 @@ describe("Client-server", function(){
 			done();
 		});
 	});
-
+	it("client.send return error when not connected to server",function(done){
+		c.send("data").catch((e)=>{
+		done();
+	});
+		
+	});
 
 	it("client allows reconnect after disconnect", function(done){
 


### PR DESCRIPTION
Once the socket is closed, you cannot read 'destroyed' from it. Better to use if(this._socket == null)